### PR TITLE
chore: misc clean up

### DIFF
--- a/packages/cli/src/commands/build/buildAction.ts
+++ b/packages/cli/src/commands/build/buildAction.ts
@@ -32,10 +32,9 @@ async function buildWebpack(buildOptions: BuildCommandOptions) {
       }),
     );
 
-    // commenting this out until we have a dummy /version endpoint
-    // await contractsInstallAction({
-    //   outdated: false, // TODO - what should this value be? figure it out.
-    // });
+    await contractsInstallAction({
+      outdated: false, // TODO - what should this value be? figure it out.
+    });
 
     compiler.run((error, stats) => {
       if (error || stats?.hasErrors()) {


### PR DESCRIPTION
Bring back contracts install. Now that we are only building non-widgets in this repo (since the widgets will get moved out) we can build everything fine.