### PR TITLE
chore: add prepack script to decouple widgets

### DIFF
--- a/packages/1fe-server/package.json
+++ b/packages/1fe-server/package.json
@@ -12,6 +12,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc --noEmit && tsup",
+    "prepack": "yarn build",
     "clean": "rm -rf dist",
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit",

--- a/packages/1fe-shell/package.json
+++ b/packages/1fe-shell/package.json
@@ -12,6 +12,7 @@
   "types": "dist/index.d.mts",
   "scripts": {
     "build": "tsc --noEmit && npx tsup",
+    "prepack": "yarn build",
     "clean": "rm -rf dist",
     "dev": "npx tsup --watch",
     "typecheck": "tsc --noEmit",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,6 +33,7 @@
   },
   "scripts": {
     "build": "tsup",
+    "prepack": "yarn build",
     "dev": "yarn build --watch",
     "dev:yalc": "NODE_OPTIONS=--max-old-space-size=10194 yarn dev --onSuccess 'yalc push'",
     "lint": "eslint \"src/**/*.ts*\" --fix",


### PR DESCRIPTION
Adds a prepack step so yarn can use `github:` URIs on these packages.