### PR TITLE
split browserslist into buildtarget and run time turnaway

### DIFF
--- a/packages/1fe-server/package.json
+++ b/packages/1fe-server/package.json
@@ -48,6 +48,8 @@
   },
   "dependencies": {
     "badge-maker": "^3.3.1",
+    "browserslist": "^4.24.5",
+    "browserslist-useragent": "^4.0.0",
     "cookie-parser": "^1.4.7",
     "ejs": "^3.1.10",
     "express": "^4.21.2",

--- a/packages/1fe-server/src/server/middlewares/browserslist.middleware.ts
+++ b/packages/1fe-server/src/server/middlewares/browserslist.middleware.ts
@@ -21,7 +21,8 @@ const browsersListMiddleware = (
 ): void => {
   try {
     const browsersListConfig =
-      readOneFEConfigs()?.dynamicConfigs?.platform?.browserslistConfig;
+      readOneFEConfigs()?.dynamicConfigs?.platform?.browserslistConfig
+        .unsupportedBrowserScreen;
 
     const { path } = req || {};
     const activeAutomatedTestFramework =
@@ -44,15 +45,14 @@ const browsersListMiddleware = (
       !isEmpty(browsersListConfig)
     ) {
       const matchesSupportedBrowser = matchesUA(userAgent, {
-        browsers: ['Chrome < 130'],
+        browsers: browsersListConfig,
         ignoreMinor: true,
         ignorePatch: true,
       });
 
-      // TODO: re-enable this when deployed
-      // if (!matchesSupportedBrowser) {
-      //   throw new Error('Unsupported Browser');
-      // }
+      if (!matchesSupportedBrowser) {
+        throw new Error('Unsupported Browser');
+      }
     }
   } catch (err) {
     next(err);

--- a/packages/1fe-server/src/server/types/one-fe-server.ts
+++ b/packages/1fe-server/src/server/types/one-fe-server.ts
@@ -17,12 +17,12 @@ type InjectNonce = {
   styleSrc?: boolean;
 };
 
-type CriticalConfigs<T> = { url: string } | { get: () => Promise<T> };
+type EcosystemConfigs<T> = { url: string } | { get: () => Promise<T> };
 
 export type OneFEConfigManagement = {
-  libraryVersions: CriticalConfigs<(ExternalLibConfig | InstalledLibConfig)[]>;
-  widgetVersions: CriticalConfigs<WidgetVersion[]>;
-  dynamicConfigs: CriticalConfigs<OneFEDynamicConfigs>;
+  libraryVersions: EcosystemConfigs<(ExternalLibConfig | InstalledLibConfig)[]>;
+  widgetVersions: EcosystemConfigs<WidgetVersion[]>;
+  dynamicConfigs: EcosystemConfigs<OneFEDynamicConfigs>;
   refreshMs: number;
 };
 

--- a/packages/1fe-server/src/server/types/raw-cdn-configs.ts
+++ b/packages/1fe-server/src/server/types/raw-cdn-configs.ts
@@ -26,7 +26,10 @@ export type WidgetConfig = {
 
 export type OneFEPlatformConfigs = {
   devtools?: Devtools;
-  browserslistConfig: string[];
+  browserslistConfig: {
+    buildTarget: string[];
+    unsupportedBrowserScreen: string[];
+  };
 };
 
 export type WidgetVersion = {

--- a/packages/1fe-shell/package.json
+++ b/packages/1fe-shell/package.json
@@ -51,7 +51,6 @@
     "@emotion/styled": "11.14.0",
     "bowser": "^2.11.0",
     "browserslist": "^4.24.4",
-    "browserslist-useragent": "^4.0.0",
     "deep-freeze": "^0.0.1",
     "emittery": "^1.0.1",
     "js-cookie": "^3.0.1",

--- a/packages/cli/src/configs/webpack/layers/targetLayer.ts
+++ b/packages/cli/src/configs/webpack/layers/targetLayer.ts
@@ -10,7 +10,7 @@ export async function getTargetLayer(
 
   const browsersListRules = (
     await getDynamicConfigs(environment)
-  ).platform.browserslistConfig.join();
+  ).platform.browserslistConfig.buildTarget.join();
 
   logger.info('Using browserslist config:', chalk.blue(browsersListRules));
 

--- a/packages/cli/src/lib/config/dynamicConfigSchema.ts
+++ b/packages/cli/src/lib/config/dynamicConfigSchema.ts
@@ -50,9 +50,14 @@ const widgetsSchema = z.object({
   configs: z.array(widgetConfigSchema),
 });
 
+const browserslistConfigSchema = z.object({
+  buildTarget: z.array(z.string()),
+  unsupportedBrowserScreen: z.array(z.string()),
+});
+
 const platformConfigSchema = z.object({
   devtools: devtoolsSchema.optional(),
-  browserslistConfig: z.array(z.string()),
+  browserslistConfig: browserslistConfigSchema,
 });
 
 export const dynamicConfigSchema = z.object({

--- a/yarn.lock
+++ b/yarn.lock
@@ -157,6 +157,8 @@ __metadata:
     "@types/react-dom": "npm:^18.2.19"
     "@types/supertest": "npm:^2.0.12"
     badge-maker: "npm:^3.3.1"
+    browserslist: "npm:^4.24.5"
+    browserslist-useragent: "npm:^4.0.0"
     cookie-parser: "npm:^1.4.7"
     ejs: "npm:^3.1.10"
     eslint: "npm:8.57.1"
@@ -206,7 +208,6 @@ __metadata:
     "@types/systemjs": "npm:^6.15.1"
     bowser: "npm:^2.11.0"
     browserslist: "npm:^4.24.4"
-    browserslist-useragent: "npm:^4.0.0"
     deep-freeze: "npm:^0.0.1"
     emittery: "npm:^1.0.1"
     eslint: "npm:8.57.1"
@@ -6825,6 +6826,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"browserslist@npm:^4.24.5":
+  version: 4.24.5
+  resolution: "browserslist@npm:4.24.5"
+  dependencies:
+    caniuse-lite: "npm:^1.0.30001716"
+    electron-to-chromium: "npm:^1.5.149"
+    node-releases: "npm:^2.0.19"
+    update-browserslist-db: "npm:^1.1.3"
+  bin:
+    browserslist: cli.js
+  checksum: 10c0/f4c1ce1a7d8fdfab5e5b88bb6e93d09e8a883c393f86801537a252da0362dbdcde4dbd97b318246c5d84c6607b2f6b47af732c1b000d6a8a881ee024bad29204
+  languageName: node
+  linkType: hard
+
 "bs-logger@npm:^0.2.6":
   version: 0.2.6
   resolution: "bs-logger@npm:0.2.6"
@@ -7050,6 +7065,13 @@ __metadata:
   version: 1.0.30001707
   resolution: "caniuse-lite@npm:1.0.30001707"
   checksum: 10c0/a1beaf84bad4f6617bbc5616d6bc0c9cab73e73f7e9e09b6466af5195b1bc393e0f6f19643d7a1c88bd3f4bfa122d7bea81cf6225ec3ade57d5b1dd3478c1a1b
+  languageName: node
+  linkType: hard
+
+"caniuse-lite@npm:^1.0.30001716":
+  version: 1.0.30001718
+  resolution: "caniuse-lite@npm:1.0.30001718"
+  checksum: 10c0/67f9ad09bc16443e28d14f265d6e468480cd8dc1900d0d8b982222de80c699c4f2306599c3da8a3fa7139f110d4b30d49dbac78f215470f479abb6ffe141d5d3
   languageName: node
   linkType: hard
 
@@ -8679,6 +8701,13 @@ __metadata:
   bin:
     ejs: bin/cli.js
   checksum: 10c0/52eade9e68416ed04f7f92c492183340582a36482836b11eab97b159fcdcfdedc62233a1bf0bf5e5e1851c501f2dca0e2e9afd111db2599e4e7f53ee29429ae1
+  languageName: node
+  linkType: hard
+
+"electron-to-chromium@npm:^1.5.149":
+  version: 1.5.159
+  resolution: "electron-to-chromium@npm:1.5.159"
+  checksum: 10c0/dc5b60a235ad04b1637b3b2af4914ac900c42813b02262a91a41d950223316f7b12de715697cf9c2d9f572f716f9422bf259ee65d86599cd2cc66e92c499ebd1
   languageName: node
   linkType: hard
 
@@ -18988,7 +19017,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"update-browserslist-db@npm:^1.1.1":
+"update-browserslist-db@npm:^1.1.1, update-browserslist-db@npm:^1.1.3":
   version: 1.1.3
   resolution: "update-browserslist-db@npm:1.1.3"
   dependencies:


### PR DESCRIPTION
- Split up browsers list
- Re-enable turnaway page
- Rearrange some dependencies

mock-cdn-assets change: https://github.com/docusign/mock-cdn-assets/pull/19