### PR TITLE
fix: package.json and tsconfig for publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "typecheck": "turbo run typecheck"
   },
   "devDependencies": {
+    "@1fe/eslint-config": "workspace:*",
+    "@1fe/typescript-config": "workspace:*",
     "@changesets/cli": "^2.29.4",
     "prettier": "^3.5.3",
     "syncpack": "^13.0.4",

--- a/packages/1fe-server/package.json
+++ b/packages/1fe-server/package.json
@@ -24,9 +24,7 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@1fe/eslint-config": "workspace:*",
     "@jest/globals": "^29.7.0",
-    "@repo/typescript-config": "0.0.0",
     "@types/cookie-parser": "^1.4.8",
     "@types/ejs": "^3.1.5",
     "@types/express": "^4.17.22",

--- a/packages/1fe-server/tsconfig.json
+++ b/packages/1fe-server/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@repo/typescript-config/react-library.json",
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "lib": ["dom", "ES2015"],
     "sourceMap": true,

--- a/packages/1fe-shell/package.json
+++ b/packages/1fe-shell/package.json
@@ -24,10 +24,8 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@1fe/eslint-config": "workspace:*",
     "@babel/preset-env": "^7.27.2",
     "@jest/globals": "^29.7.0",
-    "@repo/typescript-config": "0.0.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^14.3.1",
     "@testing-library/react-hooks": "^7.0.2",

--- a/packages/1fe-shell/tsconfig.json
+++ b/packages/1fe-shell/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@repo/typescript-config/react-library.json",
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "lib": ["dom", "ES2022"],
     "target": "ES2022",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,7 +56,6 @@
   },
   "commentDevDependencies": "These automatically packaged into the dist/index.js bundle.",
   "devDependencies": {
-    "@repo/typescript-config": "0.0.0",
     "@rollup/rollup-darwin-arm64": "^4.41.1",
     "@swc/core": "^1.11.31",
     "@types/babel__core": "^7.20.5",

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@repo/typescript-config/react-library.json",
+  "extends": "@1fe/typescript-config/react-library.json",
   "compilerOptions": {
     "target": "ES2022", // supported by Node 22+ https://node.green/#ES2022
     "lib": ["ES2022"],

--- a/packages/create-1fe-app/tsconfig.json
+++ b/packages/create-1fe-app/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "module": "ESNext",
     "moduleResolution": "bundler",

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@repo/typescript-config",
+  "name": "@1fe/typescript-config",
   "version": "0.0.0",
   "private": true,
   "license": "MIT"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "@1fe/typescript-config/base.json",
+  "compilerOptions": {
+    "target": "es2018"
+  },
+  "include": [],
+  "exclude": [],
+  "references": [
+    {
+      "path": "./packages/1fe-server"
+    },
+    {
+      "path": "./packages/1fe-shell"
+    },
+    {
+      "path": "./packages/cli"
+    },
+    {
+      "path": "./packages/create-1fe-app"
+    }
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,6 +9,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "1fe@workspace:."
   dependencies:
+    "@1fe/eslint-config": "workspace:*"
+    "@1fe/typescript-config": "workspace:*"
     "@changesets/cli": "npm:^2.29.4"
     prettier: "npm:^3.5.3"
     syncpack: "npm:^13.0.4"
@@ -29,7 +31,6 @@ __metadata:
     "@optimizely/optimizely-sdk": "npm:^4.10.1"
     "@pmmmwh/react-refresh-webpack-plugin": "npm:^0.5.16"
     "@pretty-ts-errors/formatter": "npm:^0.1.7"
-    "@repo/typescript-config": "npm:0.0.0"
     "@rollup/plugin-commonjs": "npm:^26.0.3"
     "@rollup/plugin-json": "npm:^6.1.0"
     "@rollup/plugin-node-resolve": "npm:^15.3.1"
@@ -144,9 +145,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@1fe/server@workspace:packages/1fe-server"
   dependencies:
-    "@1fe/eslint-config": "workspace:*"
     "@jest/globals": "npm:^29.7.0"
-    "@repo/typescript-config": "npm:0.0.0"
     "@types/cookie-parser": "npm:^1.4.8"
     "@types/ejs": "npm:^3.1.5"
     "@types/express": "npm:^4.17.22"
@@ -189,13 +188,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@1fe/shell@workspace:packages/1fe-shell"
   dependencies:
-    "@1fe/eslint-config": "workspace:*"
     "@babel/core": "npm:^7.27.4"
     "@babel/preset-env": "npm:^7.27.2"
     "@emotion/react": "npm:^11.14.0"
     "@emotion/styled": "npm:11.14.0"
     "@jest/globals": "npm:^29.7.0"
-    "@repo/typescript-config": "npm:0.0.0"
     "@testing-library/jest-dom": "npm:^6.6.3"
     "@testing-library/react": "npm:^14.3.1"
     "@testing-library/react-hooks": "npm:^7.0.2"
@@ -296,6 +293,12 @@ __metadata:
     webpack-dev-server: "npm:^5.2.0"
     webpack-merge: "npm:^6.0.1"
     zod: "npm:^3.25.36"
+  languageName: unknown
+  linkType: soft
+
+"@1fe/typescript-config@workspace:*, @1fe/typescript-config@workspace:packages/typescript-config":
+  version: 0.0.0-use.local
+  resolution: "@1fe/typescript-config@workspace:packages/typescript-config"
   languageName: unknown
   linkType: soft
 
@@ -4032,12 +4035,6 @@ __metadata:
   checksum: 10c0/eaef5cb46a1e413f7d1019a75990808307e08e53a39d4cf69c339432ddc03143d725decef3d6b9b5071b898da07f72a4a57c4e73f787005fcf10162973d8d7d7
   languageName: node
   linkType: hard
-
-"@repo/typescript-config@npm:0.0.0, @repo/typescript-config@workspace:packages/typescript-config":
-  version: 0.0.0-use.local
-  resolution: "@repo/typescript-config@workspace:packages/typescript-config"
-  languageName: unknown
-  linkType: soft
 
 "@rollup/plugin-commonjs@npm:^26.0.3":
   version: 26.0.3


### PR DESCRIPTION
### Problem

Our publishing workflow, which uses **Changesets**, was being blocked. The tool correctly identified that our internal, non-publishable packages (`@org/eslint-config`, `@org/tsconfig`) were listed as `devDependencies` in the `package.json` files of our *publishable* packages. This is an incorrect configuration, as packages meant for public release should not depend on internal-only packages.

### Solution

To resolve this, I've refactored our dependency and TypeScript configurations to be more centralized.

* **Hoisted Internal Dependencies:** The `@org/eslint-config` and `@org/tsconfig` packages have been removed from the individual packages and added as `devDependencies` to the monorepo's root `package.json`.
* **Implemented TypeScript Project References:** The root `tsconfig.json` now uses `references` to link to each individual package's `tsconfig.json` file.