### PR TITLE
fix: remove SSH key requirements for public repository submodules

### DIFF
--- a/.changeset/remove-ssh-keys-for-public-repos.md
+++ b/.changeset/remove-ssh-keys-for-public-repos.md
@@ -1,0 +1,17 @@
+---
+"@1fe/server": patch
+"@1fe/shell": patch  
+"@1fe/cli": patch
+"@1fe/create-1fe-app": patch
+---
+
+Remove SSH key requirements for submodules since repositories are now public
+
+Fixed Dependabot CI failures by eliminating SSH key dependencies for accessing submodules:
+
+- Converted submodule URL from SSH (`git@github.com:`) to HTTPS (`https://github.com/`)
+- Removed SSH key input requirement from setup-submodules GitHub Action
+- Simplified CI/CD workflow by removing SSH key parameters
+- All submodule operations now work with public repository access
+
+This resolves the "ssh-private-key argument is empty" error that was causing Dependabot PRs to fail in CI builds. Dependabot PRs can now run successfully without requiring repository secrets access.

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -40,8 +40,6 @@ jobs:
       - uses: ./.github/workflows/steps/setup-node
 
       - uses: ./.github/workflows/steps/setup-submodules
-        with:
-          submodule-ssh-private-key: ${{ secrets.SUBMODULE_SSH_PRIVATE_KEY }}
 
       - name: Build the project
         run: yarn build
@@ -67,8 +65,6 @@ jobs:
       - uses: ./.github/workflows/steps/setup-node
 
       - uses: ./.github/workflows/steps/setup-submodules
-        with:
-          submodule-ssh-private-key: ${{ secrets.SUBMODULE_SSH_PRIVATE_KEY }}
           self-ssh-private-key: ${{ secrets.SELF_SSH_PRIVATE_KEY }}
 
       - name: Lint the project
@@ -86,8 +82,6 @@ jobs:
       - uses: ./.github/workflows/steps/setup-node
 
       - uses: ./.github/workflows/steps/setup-submodules
-        with:
-          submodule-ssh-private-key: ${{ secrets.SUBMODULE_SSH_PRIVATE_KEY }}
           self-ssh-private-key: ${{ secrets.SELF_SSH_PRIVATE_KEY }}
 
       - name: Run unit tests
@@ -107,8 +101,6 @@ jobs:
       - uses: ./.github/workflows/steps/setup-node
 
       - uses: ./.github/workflows/steps/setup-submodules
-        with:
-          submodule-ssh-private-key: ${{ secrets.SUBMODULE_SSH_PRIVATE_KEY }}
           self-ssh-private-key: ${{ secrets.SELF_SSH_PRIVATE_KEY }}
 
       - name: Restore build artifacts
@@ -169,8 +161,6 @@ jobs:
       - uses: ./.github/workflows/steps/setup-node
 
       - uses: ./.github/workflows/steps/setup-submodules
-        with:
-          submodule-ssh-private-key: ${{ secrets.SUBMODULE_SSH_PRIVATE_KEY }}
           self-ssh-private-key: ${{ secrets.SELF_SSH_PRIVATE_KEY }}
 
       - name: Restore build artifacts

--- a/.github/workflows/steps/setup-submodules/action.yml
+++ b/.github/workflows/steps/setup-submodules/action.yml
@@ -1,24 +1,12 @@
 name: Setup Submodules
 description: Set up Git submodules for the project
 
-inputs:
-  submodule-ssh-private-key:
-    description: SSH private key for accessing submodules
-    required: true
-
 runs:
   using: 'composite'
   steps:
     - name: Mark workspace as safe
       shell: bash
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-    # TODO #61 - this action goes away when our repos become public.
-    - name: Set up SSH for submodules and yarn
-      uses: webfactory/ssh-agent@v0.9.1
-      with:
-        ssh-private-key: |
-          ${{ inputs.submodule-ssh-private-key }}
 
     - name: Initialize submodules
       shell: bash

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "apps/starter-app"]
 	path = apps/starter-app
-	url = git@github.com:docusign/1fe-starter-app.git
+	url = https://github.com/docusign/1fe-starter-app.git
 	ignore = dirty


### PR DESCRIPTION
- Convert submodule URL from SSH to HTTPS access
- Remove SSH key input from setup-submodules GitHub Action
- Simplify CI/CD workflow by removing SSH key parameters
- Add changeset for patch version bumps

Fixes Dependabot CI failures caused by missing SSH private key secrets. Dependabot PRs can now run successfully without repository secrets access.

## What does this PR do?

<!-- Brief description of changes -->

## Related Issues

<!-- Links to issues: Closes #123, Fixes #456 -->

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature  
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring

## Checklist

- [ ] Code follows project standards
- [ ] Self-reviewed my changes
- [ ] Tests pass locally
- [ ] Documentation updated (if needed)
