### PR TITLE
fix: correct YAML syntax errors in CI workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -65,7 +65,6 @@ jobs:
       - uses: ./.github/workflows/steps/setup-node
 
       - uses: ./.github/workflows/steps/setup-submodules
-          self-ssh-private-key: ${{ secrets.SELF_SSH_PRIVATE_KEY }}
 
       - name: Lint the project
         run: yarn lint
@@ -82,7 +81,6 @@ jobs:
       - uses: ./.github/workflows/steps/setup-node
 
       - uses: ./.github/workflows/steps/setup-submodules
-          self-ssh-private-key: ${{ secrets.SELF_SSH_PRIVATE_KEY }}
 
       - name: Run unit tests
         run: yarn test
@@ -101,7 +99,6 @@ jobs:
       - uses: ./.github/workflows/steps/setup-node
 
       - uses: ./.github/workflows/steps/setup-submodules
-          self-ssh-private-key: ${{ secrets.SELF_SSH_PRIVATE_KEY }}
 
       - name: Restore build artifacts
         uses: actions/cache@v4
@@ -161,7 +158,6 @@ jobs:
       - uses: ./.github/workflows/steps/setup-node
 
       - uses: ./.github/workflows/steps/setup-submodules
-          self-ssh-private-key: ${{ secrets.SELF_SSH_PRIVATE_KEY }}
 
       - name: Restore build artifacts
         uses: actions/cache@v4


### PR DESCRIPTION
- Remove malformed SSH key references from workflow steps
- Fix indentation issues that were causing workflow validation errors
- Ensure proper YAML structure for setup-submodules action calls

This resolves the 'error in your yaml syntax on line 68' issue.

## What does this PR do?

<!-- Brief description of changes -->

## Related Issues

<!-- Links to issues: Closes #123, Fixes #456 -->

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature  
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring

## Checklist

- [ ] Code follows project standards
- [ ] Self-reviewed my changes
- [ ] Tests pass locally
- [ ] Documentation updated (if needed)
