### PR TITLE
Update perms for publish packages changesets

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -130,7 +130,7 @@ jobs:
     name: 📦 Publish Packages
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       id-token: write
     # needs: [build, lint, unit-tests, e2e-tests]
     needs: [build, lint, unit-tests]


### PR DESCRIPTION
## What does this PR do?

We need to provide adequate permissions for the changeset's job to write back to the repo. 

## Related Issues

<!-- Links to issues: Closes #123, Fixes #456 -->

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature  
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring

## Checklist

- [ ] Code follows project standards
- [ ] Self-reviewed my changes
- [ ] Tests pass locally
- [ ] Documentation updated (if needed)
